### PR TITLE
Add missing del-cli dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "devDependencies": {
     "ansi": "^0.3.1",
     "chokidar": "^3.5.3",
+    "del-cli": "^5.0.0",
     "lua-types": "^2.11.0",
     "ts-node": "^10.7.0",
     "typescript": "^4.6.2",


### PR DESCRIPTION
The clean script uses a CLI program from a package that wasn't installed in the dev dependencies.